### PR TITLE
Asynchronous Image Loading for Smoother UI

### DIFF
--- a/swiftwing/ImageLoader.swift
+++ b/swiftwing/ImageLoader.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import Combine
+
+///
+/// Asynchronous image loader to prevent blocking the main thread.
+///
+class ImageLoader: ObservableObject {
+    @Published var image: UIImage?
+
+    private var cancellable: AnyCancellable?
+
+    /// Load image data asynchronously
+    func load(from data: Data) {
+        cancellable = Just(data)
+            .receive(on: DispatchQueue.global(qos: .userInitiated))
+            .map { UIImage(data: $0) }
+            .replaceError(with: nil)
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.image, on: self)
+    }
+}

--- a/swiftwing/ProcessingQueueView.swift
+++ b/swiftwing/ProcessingQueueView.swift
@@ -40,11 +40,12 @@ struct ProcessingQueueView: View {
 /// 40x60px with state-based border color
 struct ProcessingThumbnailView: View {
     let item: ProcessingItem
+    @StateObject private var imageLoader = ImageLoader()
 
     var body: some View {
         ZStack {
             // Thumbnail image
-            if let uiImage = UIImage(data: item.imageData) {
+            if let uiImage = imageLoader.image {
                 Image(uiImage: uiImage)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -62,6 +63,9 @@ struct ProcessingThumbnailView: View {
             RoundedRectangle(cornerRadius: 4)
                 .strokeBorder(item.state.borderColor, lineWidth: 2)
                 .frame(width: 40, height: 60)
+        }
+        .onAppear {
+            imageLoader.load(from: item.imageData)
         }
         .transition(.scale.combined(with: .opacity))
     }


### PR DESCRIPTION
This submission fixes a UI performance issue in the `ProcessingQueueView` by implementing asynchronous image loading. The `UIImage(data:)` call was moved to a background thread to prevent blocking the main thread, resulting in a smoother user experience.

---
*PR created automatically by Jules for task [2886115975355468666](https://jules.google.com/task/2886115975355468666) started by @jukasdrj*