### PR TITLE
Vision-detected ISBN in ProcessingItem

### DIFF
--- a/swiftwing/BookDetailSheetView.swift
+++ b/swiftwing/BookDetailSheetView.swift
@@ -144,7 +144,7 @@ struct ProcessingItemDetailSheet: View {
 #Preview {
     let imageData = Data()
     let item: ProcessingItem = {
-        var i = ProcessingItem(imageData: imageData, state: .done, progressMessage: "Ready for review")
+        var i = ProcessingItem(imageData: imageData, state: .done, progressMessage: "Ready for review", preScannedISBN: "9781234567890")
         i.bookMetadata = BookMetadata(
             title: "The Swift Programming Language",
             author: "Apple Inc.",

--- a/swiftwing/CameraView.swift
+++ b/swiftwing/CameraView.swift
@@ -323,7 +323,8 @@ struct CameraView: View {
                         await viewModel.processCaptureWithImageData(
                             itemId: itemId,
                             imageData: imageData,
-                            modelContext: modelContext
+                            modelContext: modelContext,
+                            preScannedISBN: nil
                         )
                         debugLog("INJECT_TEST_IMAGE: processCaptureWithImageData completed")
                         debugLog("INJECT_TEST_IMAGE: pendingReviewBooks.count = \(viewModel.pendingReviewBooks.count)")

--- a/swiftwing/CameraViewModel.swift
+++ b/swiftwing/CameraViewModel.swift
@@ -249,15 +249,16 @@ final class CameraViewModel {
         }
 
         // Fire and forget - process capture in parallel (non-blocking)
+        let currentISBN = detectedISBN // Capture immediately to prevent race conditions (Task 4.4)
         let itemId = UUID()
         let task = Task {
-            await processCapture(itemId: itemId)
+            await processCapture(itemId: itemId, preScannedISBN: currentISBN)
         }
         activeStreamingTasks[itemId] = task
     }
 
     // MARK: - Processing Pipeline
-    private func processCapture(itemId: UUID) async {
+    private func processCapture(itemId: UUID, preScannedISBN: String?) async {
         do {
             // Capture photo from camera (must be on main actor)
             let imageData = try await cameraManager.capturePhoto()
@@ -268,14 +269,14 @@ final class CameraViewModel {
                 fatalError("ModelContext not injected into ViewModel")
             }
 
-            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: modelContext)
+            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: modelContext, preScannedISBN: preScannedISBN)
         } catch {
             print("❌ Camera capture failed: \(error)")
             await showProcessingErrorOverlay(error.localizedDescription)
         }
     }
 
-    func processCaptureWithImageData(itemId: UUID, imageData: Data, modelContext: ModelContext) async {
+    func processCaptureWithImageData(itemId: UUID, imageData: Data, modelContext: ModelContext, preScannedISBN: String?) async {
         let startTime = CFAbsoluteTimeGetCurrent()
         var queueItem: ProcessingItem?
         var tempFileURL: URL?
@@ -299,14 +300,13 @@ final class CameraViewModel {
                 print("📴 Offline mode - queueing scan for later upload")
 
                 // Add to processing queue with offline state
-                var item = ProcessingItem(imageData: imageData, state: .offline, progressMessage: "Queued (offline)")
-                item.preScannedISBN = detectedISBN  // TODO 4.4: Pass Vision-detected ISBN
+                var item = ProcessingItem(imageData: imageData, state: .offline, progressMessage: "Queued (offline)", preScannedISBN: preScannedISBN)
                 withAnimation(.swissSpring) {
                     processingQueue.append(item)
                 }
 
                 // Queue scan in FileManager for persistent storage
-                let queuedId = try await offlineQueueManager.queueScan(imageData: imageData)
+                let queuedId = try await offlineQueueManager.queueScan(imageData: imageData, preScannedISBN: preScannedISBN)
                 print("💾 Scan queued with ID: \(queuedId)")
 
                 // Update offline queue count
@@ -318,7 +318,7 @@ final class CameraViewModel {
             }
 
             // Add to processing queue immediately with thumbnail (preprocessing state)
-            queueItem = addToQueue(imageData: imageData)
+            queueItem = addToQueue(imageData: imageData, preScannedISBN: preScannedISBN)
 
             guard let item = queueItem else { return }
 
@@ -653,7 +653,7 @@ final class CameraViewModel {
                             // Retry with new item ID
                             let retryItemId = UUID()
                             let retryTask = Task {
-                                await processCaptureWithImageData(itemId: retryItemId, imageData: originalImageData, modelContext: modelContext)
+                                await processCaptureWithImageData(itemId: retryItemId, imageData: originalImageData, modelContext: modelContext, preScannedISBN: item.preScannedISBN)
                             }
                             activeStreamingTasks[retryItemId] = retryTask
                         } else {
@@ -745,7 +745,7 @@ final class CameraViewModel {
                case .rateLimited(let retryAfter) = networkError {
                 print("⏰ Rate limited: retry after \(retryAfter ?? 0)s")
 
-                await rateLimitState.queueScan(imageData)
+                await rateLimitState.queueScan(imageData, isbn: preScannedISBN)
 
                 let retryDuration = retryAfter ?? 60.0
                 await rateLimitState.setRateLimited(retryAfter: retryDuration)
@@ -784,9 +784,8 @@ final class CameraViewModel {
     }
 
     // MARK: - Queue Management
-    private func addToQueue(imageData: Data) -> ProcessingItem {
-        var item = ProcessingItem(imageData: imageData, state: .preprocessing)
-        item.preScannedISBN = detectedISBN  // TODO 4.4: Pass Vision-detected ISBN
+    private func addToQueue(imageData: Data, preScannedISBN: String?) -> ProcessingItem {
+        var item = ProcessingItem(imageData: imageData, state: .preprocessing, preScannedISBN: preScannedISBN)
         withAnimation(.swissSpring) {
             processingQueue.append(item)
         }
@@ -874,6 +873,8 @@ final class CameraViewModel {
 
         print("🔄 Retrying failed item: \(item.id)")
 
+        let isbn = item.preScannedISBN
+
         withAnimation(.swissSpring) {
             processingQueue.removeAll { $0.id == item.id }
         }
@@ -887,7 +888,7 @@ final class CameraViewModel {
 
         let itemId = UUID()
         let task = Task {
-            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx)
+            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx, preScannedISBN: isbn)
         }
         activeStreamingTasks[itemId] = task
     }
@@ -912,10 +913,10 @@ final class CameraViewModel {
                     guard let ctx = modelContext else {
                         fatalError("ModelContext not injected into ViewModel")
                     }
-                    for imageData in queuedScans {
+                    for (imageData, isbn) in queuedScans {
                         let itemId = UUID()
                         let task = Task {
-                            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx)
+                            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx, preScannedISBN: isbn)
                         }
                         activeStreamingTasks[itemId] = task
                     }
@@ -1071,7 +1072,7 @@ final class CameraViewModel {
             for (metadata, imageData) in queuedScans {
                 let itemId = UUID()
                 let task = Task {
-                    await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx)
+                    await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx, preScannedISBN: metadata.preScannedISBN)
                 }
                 activeStreamingTasks[itemId] = task
 

--- a/swiftwing/OfflineQueueManager.swift
+++ b/swiftwing/OfflineQueueManager.swift
@@ -14,6 +14,7 @@ actor OfflineQueueManager {
         let id: UUID
         let captureDate: Date
         let imageFileName: String
+        let preScannedISBN: String?
     }
 
     // MARK: - Initialization
@@ -32,9 +33,11 @@ actor OfflineQueueManager {
     // MARK: - Public API
 
     /// Queue a scan for offline upload later
-    /// - Parameter imageData: Full-size JPEG image data to queue
+    /// - Parameters:
+    ///   - imageData: Full-size JPEG image data to queue
+    ///   - preScannedISBN: Optional Vision-detected ISBN
     /// - Returns: UUID of the queued item
-    func queueScan(imageData: Data) async throws -> UUID {
+    func queueScan(imageData: Data, preScannedISBN: String? = nil) async throws -> UUID {
         // Create queue directory if needed
         try await createQueueDirectoryIfNeeded()
 
@@ -50,7 +53,8 @@ actor OfflineQueueManager {
         let metadata = QueuedScanMetadata(
             id: scanId,
             captureDate: Date(),
-            imageFileName: imageFileName
+            imageFileName: imageFileName,
+            preScannedISBN: preScannedISBN
         )
         let metadataFileName = "\(scanId.uuidString).json"
         let metadataURL = queueDirectory.appendingPathComponent(metadataFileName)

--- a/swiftwing/ProcessingItem.swift
+++ b/swiftwing/ProcessingItem.swift
@@ -14,7 +14,7 @@ struct ProcessingItem: Identifiable, Equatable {
     var originalImageData: Data?  // Original full-size image for retry (US-407)
     var tempFileURL: URL?  // Temporary JPEG file URL for cleanup (US-406)
     var jobId: String?     // Talaria job ID for server cleanup (US-406)
-    var preScannedISBN: String? = nil  // Vision-detected ISBN from barcode scanner (TODO 4.4)
+    var preScannedISBN: String? = nil  // Vision-detected ISBN from barcode scanner
     var segmentedPreview: Data?  // Segmented image preview with bounding boxes (Task 5)
     var detectedBookCount: Int?  // Number of books detected in segmented preview (Task 5)
     var currentBookIndex: Int?   // Current book being processed in multi-book scan (Task 5)
@@ -27,7 +27,7 @@ struct ProcessingItem: Identifiable, Equatable {
 
     // MARK: - Retry Context for Failed Result Fetches (Fix #2)
 
-    init(imageData: Data, state: ProcessingState = .uploading, progressMessage: String? = nil) {
+    init(imageData: Data, state: ProcessingState = .uploading, progressMessage: String? = nil, preScannedISBN: String? = nil) {
         self.id = UUID()
         self.thumbnailData = Self.generateThumbnail(from: imageData)
         self.captureDate = Date()
@@ -37,6 +37,7 @@ struct ProcessingItem: Identifiable, Equatable {
         self.originalImageData = imageData  // Store for retry (US-407)
         self.tempFileURL = nil
         self.jobId = nil
+        self.preScannedISBN = preScannedISBN
     }
 
     /// Generates optimized 60x90px thumbnail from full image data

--- a/swiftwing/ProcessingQueueView.swift
+++ b/swiftwing/ProcessingQueueView.swift
@@ -133,13 +133,13 @@ struct ProcessingThumbnailView: View {
     let sampleData = UIImage(systemName: "book")!
         .pngData() ?? Data()
 
-    var errorItem = ProcessingItem(imageData: sampleData, state: .error)
+    var errorItem = ProcessingItem(imageData: sampleData, state: .error, preScannedISBN: nil)
     errorItem.errorMessage = "No text found"
 
     let items = [
-        ProcessingItem(imageData: sampleData, state: .uploading, progressMessage: "Uploading..."),
-        ProcessingItem(imageData: sampleData, state: .analyzing, progressMessage: "Looking..."),
-        ProcessingItem(imageData: sampleData, state: .done),
+        ProcessingItem(imageData: sampleData, state: .uploading, progressMessage: "Uploading...", preScannedISBN: nil),
+        ProcessingItem(imageData: sampleData, state: .analyzing, progressMessage: "Looking...", preScannedISBN: "9781234567890"),
+        ProcessingItem(imageData: sampleData, state: .done, preScannedISBN: "9780987654321"),
         errorItem
     ]
 

--- a/swiftwing/RateLimitState.swift
+++ b/swiftwing/RateLimitState.swift
@@ -13,7 +13,7 @@ actor RateLimitState {
     private(set) var retryAfterDate: Date?
 
     /// Queued image scans during rate limit (preserved to retry after cooldown)
-    private var queuedScans: [Data] = []
+    private var queuedScans: [(data: Data, isbn: String?)] = []
 
     // MARK: - Public API
 
@@ -44,15 +44,17 @@ actor RateLimitState {
     }
 
     /// Queue an image scan during rate limit
-    /// - Parameter imageData: JPEG image data to queue
-    func queueScan(_ imageData: Data) {
-        queuedScans.append(imageData)
+    /// - Parameters:
+    ///   - imageData: JPEG image data to queue
+    ///   - isbn: Optional Vision-detected ISBN
+    func queueScan(_ imageData: Data, isbn: String? = nil) {
+        queuedScans.append((data: imageData, isbn: isbn))
         print("📥 Queued scan (\(queuedScans.count) total in queue)")
     }
 
     /// Get all queued scans and clear the queue
-    /// - Returns: Array of queued image data
-    func dequeueAllScans() -> [Data] {
+    /// - Returns: Array of queued (image data, isbn) tuples
+    func dequeueAllScans() -> [(data: Data, isbn: String?)] {
         let scans = queuedScans
         queuedScans.removeAll()
         print("📤 Dequeued \(scans.count) scans")


### PR DESCRIPTION
This change ensures that the ISBN detected by the Vision/barcode scanner is correctly captured at the moment of shutter press and passed through all stages of the processing pipeline, including offline queueing and rate limiting. This maintains data integrity during the asynchronous identification process.

---
*PR created automatically by Jules for task [16853413958481754476](https://jules.google.com/task/16853413958481754476) started by @jukasdrj*