### PR TITLE
⚡ Optimize review needed count calculation in LibraryView

### DIFF
--- a/swiftwing/LibraryView.swift
+++ b/swiftwing/LibraryView.swift
@@ -369,7 +369,7 @@ struct LibraryView: View {
         cachedUniqueAuthorsCount = Set(books.map { $0.author }).count
 
         // 2. Review Needed Count (O(n))
-        cachedReviewNeededCount = books.filter { ($0.spineConfidence ?? 1.0) < 0.8 }.count
+        cachedReviewNeededCount = books.lazy.filter { ($0.spineConfidence ?? 1.0) < 0.8 }.count
 
         // 3. Most Common Format (O(n))
         let formatCounts = Dictionary(grouping: books.compactMap { $0.format }, by: { $0 })

--- a/swiftwingTests/PerformanceBenchmarkTests.swift
+++ b/swiftwingTests/PerformanceBenchmarkTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import swiftwing
+
+final class PerformanceBenchmarkTests: XCTestCase {
+
+    struct TestBook {
+        let spineConfidence: Double?
+    }
+
+    // Measure baseline performance using filter
+    func testFilterPerformance() {
+        let books = (0..<1_000_000).map { _ in TestBook(spineConfidence: Double.random(in: 0...1)) }
+
+        measure {
+            let count = books.filter { ($0.spineConfidence ?? 1.0) < 0.8 }.count
+            _ = count
+        }
+    }
+
+    // Measure optimized performance using lazy filter
+    func testLazyFilterPerformance() {
+        let books = (0..<1_000_000).map { _ in TestBook(spineConfidence: Double.random(in: 0...1)) }
+
+        measure {
+            let count = books.lazy.filter { ($0.spineConfidence ?? 1.0) < 0.8 }.count
+            _ = count
+        }
+    }
+}


### PR DESCRIPTION
This PR optimizes the `reviewNeededCount` calculation in `LibraryView` by using `lazy.filter` instead of eager `filter`. This avoids the allocation of an intermediate array containing the filtered books, which is purely overhead since we only need the count.

For a library of N books, this changes the auxiliary space complexity from O(N) to O(1). Time complexity remains O(N).

Added `swiftwingTests/PerformanceBenchmarkTests.swift` which includes a benchmark test `testLazyFilterPerformance` demonstrating the improvement.

---
*PR created automatically by Jules for task [2444133303821868175](https://jules.google.com/task/2444133303821868175) started by @jukasdrj*