### PR TITLE
⚡ Move synchronous file I/O to background task in CameraViewModel

### DIFF
--- a/swiftwing/CameraViewModel.swift
+++ b/swiftwing/CameraViewModel.swift
@@ -318,7 +318,10 @@ final class CameraViewModel {
             }
 
             // Read processed image data for upload
-            let uploadData = try Data(contentsOf: fileURL)
+            // US-410: Performance optimization - move file I/O off main thread
+            let uploadData = try await Task.detached(priority: .userInitiated) {
+                try Data(contentsOf: fileURL)
+            }.value
 
             // US-410: Performance optimization - limit concurrent SSE streams to 5
             await streamManager.acquireStreamSlot(scanId: itemId)


### PR DESCRIPTION
💡 **What:**
Moved the synchronous file read `Data(contentsOf: fileURL)` inside `CameraViewModel.processCaptureWithImageData` to a `Task.detached(priority: .userInitiated)` block.

🎯 **Why:**
`CameraViewModel` is an `@MainActor` isolated class. Synchronous file I/O operations block the main thread, leading to potential UI freezes and frame drops, especially with large image files or slow storage. Offloading this to a background task ensures the main thread remains free for UI updates.

📊 **Measured Improvement:**
While direct performance measurements were not possible in this environment due to the lack of `XCTMetric` and device access, this change follows standard Swift Concurrency best practices for avoiding main thread blocking. By moving the blocking I/O to a background thread, we eliminate a potential source of UI jank during the capture flow.


---
*PR created automatically by Jules for task [1402681040339540856](https://jules.google.com/task/1402681040339540856) started by @jukasdrj*