### PR TITLE
Pass Vision-detected ISBN through processing pipeline

### DIFF
--- a/swiftwing/CameraViewModel.swift
+++ b/swiftwing/CameraViewModel.swift
@@ -213,6 +213,9 @@ final class CameraViewModel {
             return
         }
 
+        // Capture ISBN at the moment of shutter press (to avoid race conditions)
+        let capturedISBN = detectedISBN
+
         // Show flash immediately (100ms animation)
         withAnimation(.easeOut(duration: 0.1)) {
             showFlash = true
@@ -229,13 +232,13 @@ final class CameraViewModel {
         // Fire and forget - process capture in parallel (non-blocking)
         let itemId = UUID()
         let task = Task {
-            await processCapture(itemId: itemId)
+            await processCapture(itemId: itemId, isbn: capturedISBN)
         }
         Task { await scanCoordinator.trackJob(id: itemId, task: task) }
     }
 
     // MARK: - Processing Pipeline
-    private func processCapture(itemId: UUID) async {
+    private func processCapture(itemId: UUID, isbn: String? = nil) async {
         do {
             // Capture photo from camera (must be on main actor)
             let imageData = try await cameraManager.capturePhoto()
@@ -248,14 +251,14 @@ final class CameraViewModel {
                 return
             }
 
-            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: modelContext)
+            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: modelContext, isbn: isbn)
         } catch {
             print("❌ Camera capture failed: \(error)")
             await showProcessingErrorOverlay(error.localizedDescription)
         }
     }
 
-    func processCaptureWithImageData(itemId: UUID, imageData: Data, modelContext: ModelContext) async {
+    func processCaptureWithImageData(itemId: UUID, imageData: Data, modelContext: ModelContext, isbn: String? = nil) async {
         let startTime = CFAbsoluteTimeGetCurrent()
         var queueItem: ProcessingItem?
         var tempFileURL: URL?
@@ -278,14 +281,13 @@ final class CameraViewModel {
                 print("📴 Offline mode - queueing scan for later upload")
 
                 // Add to processing queue with offline state
-                var item = ProcessingItem(imageData: imageData, state: .offline, progressMessage: "Queued (offline)")
-                item.preScannedISBN = detectedISBN  // TODO 4.4: Pass Vision-detected ISBN
+                let item = ProcessingItem(imageData: imageData, state: .offline, progressMessage: "Queued (offline)", preScannedISBN: isbn)
                 withAnimation(.swissSpring) {
                     processingQueue.append(item)
                 }
 
                 // Queue scan in FileManager for persistent storage
-                let queuedId = try await offlineQueueManager.queueScan(imageData: imageData)
+                let queuedId = try await offlineQueueManager.queueScan(imageData: imageData, isbn: isbn)
                 print("💾 Scan queued with ID: \(queuedId)")
 
                 // Update offline queue count
@@ -297,7 +299,7 @@ final class CameraViewModel {
             }
 
             // Add to processing queue immediately with thumbnail (preprocessing state)
-            queueItem = addToQueue(imageData: imageData)
+            queueItem = addToQueue(imageData: imageData, isbn: isbn)
 
             guard let item = queueItem else { return }
 
@@ -381,6 +383,7 @@ final class CameraViewModel {
 
                     // Auto-retry once after 2 second delay
                     if let originalImageData = item.originalImageData {
+                        let retryISBN = item.preScannedISBN
                         Task {
                             try? await Task.sleep(nanoseconds: 2_000_000_000)
                             withAnimation(.swissSpring) {
@@ -389,7 +392,7 @@ final class CameraViewModel {
 
                             let retryItemId = UUID()
                             let retryTask = Task {
-                                await self.processCaptureWithImageData(itemId: retryItemId, imageData: originalImageData, modelContext: modelContext)
+                                await self.processCaptureWithImageData(itemId: retryItemId, imageData: originalImageData, modelContext: modelContext, isbn: retryISBN)
                             }
                             await self.scanCoordinator.trackJob(id: retryItemId, task: retryTask)
                         }
@@ -481,7 +484,7 @@ final class CameraViewModel {
                case .rateLimited(let retryAfter) = networkError {
                 print("⏰ Rate limited: retry after \(retryAfter ?? 0)s")
 
-                await rateLimitState.queueScan(imageData)
+                await rateLimitState.queueScan(imageData, isbn: isbn)
 
                 let retryDuration = retryAfter ?? 60.0
                 await rateLimitState.setRateLimited(retryAfter: retryDuration)
@@ -523,9 +526,8 @@ final class CameraViewModel {
     }
 
     // MARK: - Queue Management
-    private func addToQueue(imageData: Data) -> ProcessingItem {
-        var item = ProcessingItem(imageData: imageData, state: .preprocessing)
-        item.preScannedISBN = detectedISBN  // TODO 4.4: Pass Vision-detected ISBN
+    private func addToQueue(imageData: Data, isbn: String? = nil) -> ProcessingItem {
+        let item = ProcessingItem(imageData: imageData, state: .preprocessing, preScannedISBN: isbn)
         withAnimation(.swissSpring) {
             processingQueue.append(item)
         }
@@ -626,8 +628,9 @@ final class CameraViewModel {
         }
 
         let itemId = UUID()
+        let retryISBN = item.preScannedISBN
         let task = Task {
-            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx)
+            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx, isbn: retryISBN)
         }
         Task { await scanCoordinator.trackJob(id: itemId, task: task) }
     }
@@ -653,10 +656,10 @@ final class CameraViewModel {
                         print("❌ ModelContext not injected — cannot process rate-limit queue")
                         break
                     }
-                    for imageData in queuedScans {
+                    for (imageData, isbn) in queuedScans {
                         let itemId = UUID()
                         let task = Task {
-                            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx)
+                            await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx, isbn: isbn)
                         }
                         await scanCoordinator.trackJob(id: itemId, task: task)
                     }
@@ -785,7 +788,7 @@ final class CameraViewModel {
             for (metadata, imageData) in queuedScans {
                 let itemId = UUID()
                 let task = Task {
-                    await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx)
+                    await processCaptureWithImageData(itemId: itemId, imageData: imageData, modelContext: ctx, isbn: metadata.isbn)
                 }
                 await scanCoordinator.trackJob(id: itemId, task: task)
 

--- a/swiftwing/OfflineQueueManager.swift
+++ b/swiftwing/OfflineQueueManager.swift
@@ -14,6 +14,7 @@ actor OfflineQueueManager {
         let id: UUID
         let captureDate: Date
         let imageFileName: String
+        let isbn: String?
     }
 
     // MARK: - Initialization
@@ -33,8 +34,9 @@ actor OfflineQueueManager {
 
     /// Queue a scan for offline upload later
     /// - Parameter imageData: Full-size JPEG image data to queue
+    /// - Parameter isbn: Vision-detected ISBN (optional)
     /// - Returns: UUID of the queued item
-    func queueScan(imageData: Data) async throws -> UUID {
+    func queueScan(imageData: Data, isbn: String? = nil) async throws -> UUID {
         // Create queue directory if needed
         try await createQueueDirectoryIfNeeded()
 
@@ -50,7 +52,8 @@ actor OfflineQueueManager {
         let metadata = QueuedScanMetadata(
             id: scanId,
             captureDate: Date(),
-            imageFileName: imageFileName
+            imageFileName: imageFileName,
+            isbn: isbn
         )
         let metadataFileName = "\(scanId.uuidString).json"
         let metadataURL = queueDirectory.appendingPathComponent(metadataFileName)

--- a/swiftwing/ProcessingItem.swift
+++ b/swiftwing/ProcessingItem.swift
@@ -27,7 +27,7 @@ struct ProcessingItem: Identifiable, Equatable {
 
     // MARK: - Retry Context for Failed Result Fetches (Fix #2)
 
-    init(imageData: Data, state: ProcessingState = .uploading, progressMessage: String? = nil) {
+    init(imageData: Data, state: ProcessingState = .uploading, progressMessage: String? = nil, preScannedISBN: String? = nil) {
         self.id = UUID()
         self.thumbnailData = Self.generateThumbnail(from: imageData)
         self.captureDate = Date()
@@ -37,6 +37,7 @@ struct ProcessingItem: Identifiable, Equatable {
         self.originalImageData = imageData  // Store for retry (US-407)
         self.tempFileURL = nil
         self.jobId = nil
+        self.preScannedISBN = preScannedISBN
     }
 
     /// Generates optimized 60x90px thumbnail from full image data

--- a/swiftwing/RateLimitState.swift
+++ b/swiftwing/RateLimitState.swift
@@ -13,7 +13,7 @@ actor RateLimitState {
     private(set) var retryAfterDate: Date?
 
     /// Queued image scans during rate limit (preserved to retry after cooldown)
-    private var queuedScans: [Data] = []
+    private var queuedScans: [(imageData: Data, isbn: String?)] = []
 
     // MARK: - Public API
 
@@ -45,14 +45,14 @@ actor RateLimitState {
 
     /// Queue an image scan during rate limit
     /// - Parameter imageData: JPEG image data to queue
-    func queueScan(_ imageData: Data) {
-        queuedScans.append(imageData)
+    func queueScan(_ imageData: Data, isbn: String? = nil) {
+        queuedScans.append((imageData: imageData, isbn: isbn))
         print("📥 Queued scan (\(queuedScans.count) total in queue)")
     }
 
     /// Get all queued scans and clear the queue
-    /// - Returns: Array of queued image data
-    func dequeueAllScans() -> [Data] {
+    /// - Returns: Array of queued image data and optional ISBN
+    func dequeueAllScans() -> [(imageData: Data, isbn: String?)] {
         let scans = queuedScans
         queuedScans.removeAll()
         print("📤 Dequeued \(scans.count) scans")


### PR DESCRIPTION
This change ensures that the Vision-detected ISBN is correctly captured at the moment of shutter press and propagated through the entire processing pipeline, including offline queuing, rate-limit queuing, and retry scenarios.

Key changes:
- `ProcessingItem.swift`: Added `preScannedISBN` to initializer.
- `RateLimitState.swift`: Changed `queuedScans` to store `(Data, String?)` tuples.
- `OfflineQueueManager.swift`: Added `isbn` to `QueuedScanMetadata`.
- `CameraViewModel.swift`: Updated method signatures and logic to pass `isbn` consistently.

---
*PR created automatically by Jules for task [10182356155468089060](https://jules.google.com/task/10182356155468089060) started by @jukasdrj*