### PR TITLE
⚡ Optimize OfflineQueueManager with parallel async I/O

### DIFF
--- a/swiftwing/OfflineQueueManager.swift
+++ b/swiftwing/OfflineQueueManager.swift
@@ -18,10 +18,14 @@ actor OfflineQueueManager {
 
     // MARK: - Initialization
 
-    init() {
-        // Create offline queue directory in app's documents folder
-        let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        self.queueDirectory = documentsDir.appendingPathComponent("OfflineQueue", isDirectory: true)
+    init(queueDirectory: URL? = nil) {
+        if let queueDirectory = queueDirectory {
+            self.queueDirectory = queueDirectory
+        } else {
+            // Create offline queue directory in app's documents folder
+            let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            self.queueDirectory = documentsDir.appendingPathComponent("OfflineQueue", isDirectory: true)
+        }
 
         // Create directory if it doesn't exist (non-blocking)
         Task {
@@ -77,30 +81,36 @@ actor OfflineQueueManager {
 
         let metadataFiles = contents.filter { $0.pathExtension == "json" }
 
-        var results: [(metadata: QueuedScanMetadata, imageData: Data)] = []
+        print("🔄 Loading \(metadataFiles.count) queued scans in parallel...")
 
-        for metadataFile in metadataFiles {
-            do {
-                // Load metadata
-                let metadataData = try Data(contentsOf: metadataFile)
-                let metadata = try JSONDecoder().decode(QueuedScanMetadata.self, from: metadataData)
+        // Capture queueDirectory to avoid actor isolation issues inside TaskGroup
+        let queueDir = self.queueDirectory
 
-                // Load corresponding image
-                let imageURL = queueDirectory.appendingPathComponent(metadata.imageFileName)
-                let imageData = try Data(contentsOf: imageURL)
-
-                results.append((metadata: metadata, imageData: imageData))
-            } catch {
-                print("⚠️ Failed to load queued scan from \(metadataFile.lastPathComponent): \(error)")
-                // Continue with other scans even if one fails
+        return await withTaskGroup(of: (QueuedScanMetadata, Data)?.self) { group in
+            for metadataFile in metadataFiles {
+                group.addTask {
+                    do {
+                        return try await self.loadScan(metadataFile: metadataFile, queueDirectory: queueDir)
+                    } catch {
+                        print("⚠️ Failed to load queued scan from \(metadataFile.lastPathComponent): \(error)")
+                        return nil
+                    }
+                }
             }
+
+            var results: [(metadata: QueuedScanMetadata, imageData: Data)] = []
+            for await result in group {
+                if let result = result {
+                    results.append(result)
+                }
+            }
+
+            // Sort by capture date (oldest first)
+            results.sort { $0.metadata.captureDate < $1.metadata.captureDate }
+
+            print("📂 Found \(results.count) queued offline scans")
+            return results
         }
-
-        // Sort by capture date (oldest first)
-        results.sort { $0.metadata.captureDate < $1.metadata.captureDate }
-
-        print("📂 Found \(results.count) queued offline scans")
-        return results
     }
 
     /// Remove a queued scan after successful upload
@@ -146,5 +156,21 @@ actor OfflineQueueManager {
             )
             print("📁 Created offline queue directory")
         }
+    }
+
+    /// Loads scan data asynchronously and safely off the main actor
+    /// - Parameters:
+    ///   - metadataFile: URL to the metadata JSON file
+    ///   - queueDirectory: The base directory for queued files
+    /// - Returns: Tuple containing metadata and image data
+    nonisolated func loadScan(metadataFile: URL, queueDirectory: URL) async throws -> (QueuedScanMetadata, Data) {
+        // Use URLSession for async non-blocking file I/O
+        let (metadataData, _) = try await URLSession.shared.data(from: metadataFile)
+        let metadata = try JSONDecoder().decode(QueuedScanMetadata.self, from: metadataData)
+
+        let imageURL = queueDirectory.appendingPathComponent(metadata.imageFileName)
+        let (imageData, _) = try await URLSession.shared.data(from: imageURL)
+
+        return (metadata, imageData)
     }
 }


### PR DESCRIPTION
This PR optimizes `OfflineQueueManager.getAllQueuedScans` by replacing serial synchronous file I/O with parallel asynchronous tasks.

Changes:
1.  **Parallel Loading**: Uses `withTaskGroup` to load metadata and images concurrently.
2.  **Non-blocking I/O**: Replaces `Data(contentsOf:)` (blocking) with `URLSession.shared.data(from:)` (async) to avoid blocking the actor.
3.  **Actor Safety**: Moves the loading logic to a `nonisolated` helper function to ensure it runs off the actor's executor, and correctly captures `queueDirectory` to avoid actor isolation violations.
4.  **Testability**: Updates `init` to allow injecting a custom directory (e.g., for temporary test files).
5.  **Benchmark**: Adds `OfflineQueuePerformanceTests.swift` to measure performance (intended for future use by developers with a working environment).

Performance Rationale:
- Previous implementation blocked the actor for each file read, serializing I/O.
- New implementation allows multiple I/O operations to be in flight simultaneously (up to the system's limit) and does not block the actor, allowing other actor operations to proceed.


---
*PR created automatically by Jules for task [14587323953615262214](https://jules.google.com/task/14587323953615262214) started by @jukasdrj*