### PR TITLE
fix: add diagnostic logging to silent catch blocks

### DIFF
--- a/swiftwing/CameraManager.swift
+++ b/swiftwing/CameraManager.swift
@@ -1,10 +1,13 @@
 import AVFoundation
+import OSLog
 // Import Vision framework types and service
 import Vision
 
 #if canImport(UIKit)
     import UIKit
 #endif
+
+private let logger = Logger(subsystem: "com.ooheynerds.swiftwing", category: "camera")
 
 /// Camera session manager for SwiftUI
 /// AVCaptureSession must be managed on main thread per Apple documentation
@@ -265,7 +268,9 @@ class CameraManager: ObservableObject {
                 device.videoZoomFactor = clampedFactor
                 device.unlockForConfiguration()
                 currentZoomFactor = clampedFactor
-            } catch {}
+            } catch {
+                logger.warning("Failed to configure zoom: \(error.localizedDescription)")
+            }
         #endif
     }
 
@@ -284,7 +289,9 @@ class CameraManager: ObservableObject {
                 device.exposureMode = .autoExpose
             }
             device.unlockForConfiguration()
-        } catch {}
+        } catch {
+            logger.warning("Failed to configure focus: \(error.localizedDescription)")
+        }
     }
 
     // Notification logic (unchanged)

--- a/swiftwing/CaptureGuidanceView.swift
+++ b/swiftwing/CaptureGuidanceView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import Foundation
 
 /// Smart capture guidance overlay that displays real-time feedback to users
 /// during camera capture. Uses Swiss Glass design system with smooth animations.
@@ -169,9 +168,10 @@ private struct CaptureGuidanceAnimationPreview: View {
             .spineDetected
         ]
 
-        var currentIndex = 0
-        Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
-            Task { @MainActor in
+        Task { @MainActor in
+            var currentIndex = 0
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
                 currentIndex = (currentIndex + 1) % states.count
                 currentGuidance = states[currentIndex]
             }

--- a/swiftwing/ReviewQueueManager.swift
+++ b/swiftwing/ReviewQueueManager.swift
@@ -197,7 +197,7 @@ final class ReviewQueueManager {
                 return
             }
         } catch {
-            // Proceed with add on detection failure
+            logger.warning("Duplicate detection failed, proceeding with add: \(error)")
         }
 
         // Use resolved values (prefers user edits over AI results)

--- a/swiftwing/SwiftwingApp.swift
+++ b/swiftwing/SwiftwingApp.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import OSLog
 
 @main
 struct SwiftwingApp: App {
@@ -12,6 +13,8 @@ struct SwiftwingApp: App {
         do {
             return try ModelContainer(for: schema, configurations: [modelConfiguration])
         } catch {
+            Logger(subsystem: "com.ooheynerds.swiftwing", category: "app-init")
+                .fault("Could not create ModelContainer: \(error)")
             fatalError("Could not create ModelContainer: \(error)")
         }
     }()


### PR DESCRIPTION
## Summary

- **CameraManager.swift**: Replace empty `catch {}` blocks in `setZoom` and `setFocusPoint` with `logger.warning()` calls — camera configuration failures were silently swallowed
- **ReviewQueueManager.swift**: Log duplicate detection failures instead of silent proceed — could lead to duplicate books with no diagnostic trail
- **SwiftwingApp.swift**: Add `OSLog .fault` before `fatalError` on `ModelContainer` init failure — ensures crash reason is captured in system logs
- **CaptureGuidanceView.swift**: Replace `Timer` + `Task { @MainActor }` pattern with `Task.sleep` loop — fixes Swift 6.2 data race error on `currentIndex`

## Context

Also reviewed and closed PR #19 and PR #20 (both had merge conflicts and convention violations — `Task.detached` usage and `URLSession` misuse for local file I/O).

## Build verification

```
{
  "status": "success",
  "summary": { "errors": 0, "warnings": 0 }
}
```

## Test plan

- [ ] Verify camera zoom/focus works normally (logging should only appear on failure)
- [ ] Add a book and check console for duplicate detection log (only on SwiftData query failure)
- [ ] Preview "Animated States" in CaptureGuidanceView cycles through states correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)